### PR TITLE
Fixing issue #23 and hardening the repo installation tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ overriding the `pdns_rec_install_repo` variable value as follows:
     - hosts: pdns-recursors
       roles:
       - { role: PowerDNS.pdns_recursor,
-          pdns_rec_install_repo: "{{ pdns_rec_official_pdns_master }}"
+          pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_master }}"
 
     # Install the PowerDNS Recursor from the '40' branch
     - hosts: pdns-recursors
       roles:
       - { role: PowerDNS.pdns_recursor,
-          pdns_rec_install_repo: "{{ pdns_rec_official_pdns_40 }}"
+          pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_40 }}"
 
 The roles also supports custom repositories
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 
 # By default the PowerDNS Recursor is installed from the os default repositories.
-pdns_rec_install_repo: False
-#
+pdns_rec_install_repo: ""
+
 # Install the EPEL repository.
 # EPEL is needed to satisfy some PowerDNS Recursor dependencies like protobuf
 pdns_rec_install_epel: True
-#
+
 # You can install the PowerDNS Recursor package from the 'master' branch as
 # follows:
 # - hosts: all

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,8 +1,11 @@
 ---
 
-ansible:
-   requirements_file: requirements.yml
-   # verbose: true
+#ansible:
+#   verbose: true
+
+dependency:
+  name: galaxy
+  requirements_file: requirements.yml
 
 driver:
   name: vagrant

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,7 +2,7 @@
 
 - hosts: all
   vars:
-    pdns_rec_install_repo: "{{ pdns_rec_official_pdns_master }}"
+    pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_master }}"
     pdns_rec_config:
       allow-from: "198.51.100.0/24"
   roles:

--- a/tasks/inspect-Debian.yml
+++ b/tasks/inspect-Debian.yml
@@ -10,7 +10,7 @@
 - name: Export the pdns_recursor_version variable for Debian
   set_fact:
     pdns_recursor_version: |
-      {% if pdns_rec_install_repo %}
+      {% if pdns_rec_install_repo != "" %}
       {{ pdns_recursor_version_result.versions | selectattr('repo_site', 'equalto', pdns_rec_install_repo['apt_repo_origin']) | map(attribute='version') | sort(reverse=True) | first }}
       {% else %}
       {{ pdns_recursor_version_result.versions | map(attribute='version') | sort(reverse=True) | first }}

--- a/tasks/inspect-RedHat.yml
+++ b/tasks/inspect-RedHat.yml
@@ -10,7 +10,7 @@
 - name: Export the pdns_recursor_version variable for RedHat
   set_fact:
     pdns_recursor_version: |
-      {% if pdns_rec_install_repo %}
+      {% if pdns_rec_install_repo != "" %}
       {{ pdns_recursor_version_result.versions | selectattr('repo_name', 'equalto', pdns_rec_install_repo['yum_repo_name']) | map(attribute='version') | sort(reverse=True) | first }}
       {% else %}
       {{ pdns_recursor_version_result.versions | map(attribute='version') | sort(reverse=True) | first }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: "Setup PowerDNS repo"
   include: "repo-{{ ansible_os_family }}.yml"
-  when: pdns_rec_install_repo
+  when: pdns_rec_install_repo != ""
   tags:
     - install
     - repository

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+
+default_pdns_rec_user: "pdns"
+default_pdns_rec_group: "pdns"
+default_pdns_rec_config_dir: "/etc/powerdns"
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,5 @@
 ---
 
-default_pdns_rec_user: "pdns"
-default_pdns_rec_group: "pdns"
-default_pdns_rec_config_dir: "/etc/powerdns"
-
 pdns_rec_powerdns_repo_master:
   apt_repo_origin: "repo.powerdns.com"
   apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-master main"


### PR DESCRIPTION
This PR aims to fix issue #23 and improve the way we handle the setup of customer PowerDNS Recursor repositories.

An alternative fix for issue #23 would be adding `ignore_errors: True` to the `include_vars` task.