### PR TITLE
Handle different version string for Debian and CentOS

### DIFF
--- a/tasks/install-pdns.yml
+++ b/tasks/install-pdns.yml
@@ -1,0 +1,26 @@
+---
+
+- block:
+
+  - name: Prefix the version with the correct separator on RedHat
+    set_fact:
+      pdns_rec_package_version: "-{{ pdns_rec_package_version }}"
+    when: ansible_os_family == 'RedHat'
+
+  - name: Prefix the version with the correct separator on Debian
+    set_fact:
+      pdns_rec_package_version: "={{ pdns_rec_package_version }}"
+    when: ansible_os_family == 'Debian'
+
+  when: pdns_rec_package_version != ''
+  tags:
+    - install
+
+- name: Install PowerDNS
+  package:
+    name: "{{ pdns_rec_package_name }}{{ pdns_rec_package_version }}"
+    state: present
+  tags:
+    - install
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,29 +10,7 @@
     - install
     - repository
 
-- name: Get the latest PowerDNS Recursor version from the Package Manager
-  include: "inspect-{{ ansible_os_family }}.yml"
-  when: "pdns_rec_package_version == ''"
-
-- name: Append the version to the PowerDNS Recursor package name 
-  set_fact:
-    pdns_rec_package_name: "{{ pdns_rec_package_name }}-{{ pdns_rec_package_version }}"
-
-- name: Generate the PowerDNS Recursor configuration 
-  include: configure.yml
-  tags:
-    - config
-
-- name: Install EPEL (when required)
-  include: install-epel.yml
-  when: ansible_os_family == 'RedHat' and pdns_rec_install_epel
-  tags:
-    - install
-
-- name: Install the PowerDNS Recursor package
-  package:
-    name: "{{ pdns_rec_package_name }}"
-    state: present
+- include: install-pdns.yml
   tags:
     - install
 


### PR DESCRIPTION
Copied from https://github.com/PowerDNS/pdns-ansible/commit/09585360b1eca1f3fd34e41114ca76d5bcf341c5 since it's also needed for recursor.

Additional string mangling because pdns_rec_package_version appears to contain a new line (and apt chokes on that). A fix in atosatto.packages-extras (sanitize the version string over there) might be better, this is a quick workaround.