### PR TITLE
add special case for "threads" variable

### DIFF
--- a/templates/recursor.conf.j2
+++ b/templates/recursor.conf.j2
@@ -4,7 +4,7 @@ setgid={{ pdns_rec_group }}
 
 {% for config_item, value in pdns_rec_config.items() | sort() %}
 {% if config_item not in ["config-dir", "setuid", "setgid"] %}
-{%- if config_item == 'threads' and value == '1' %}
+{%- if config_item == 'threads' and value == 1 %}
 {{ config_item }}={{ value | string }}
 {%- elif value == True %}
 {{ config_item }}=yes

--- a/templates/recursor.conf.j2
+++ b/templates/recursor.conf.j2
@@ -4,7 +4,7 @@ setgid={{ pdns_rec_group }}
 
 {% for config_item, value in pdns_rec_config.items() | sort() %}
 {% if config_item not in ["config-dir", "setuid", "setgid"] %}
-{%- if config_item == 'threads' %}
+{%- if config_item == 'threads' and value == '1' %}
 {{ config_item }}={{ value | string }}
 {%- elif value == True %}
 {{ config_item }}=yes

--- a/templates/recursor.conf.j2
+++ b/templates/recursor.conf.j2
@@ -4,7 +4,7 @@ setgid={{ pdns_rec_group }}
 
 {% for config_item, value in pdns_rec_config.items() | sort() %}
 {% if config_item not in ["config-dir", "setuid", "setgid"] %}
-{%- if config_item == 'threads' and value == 1 %}
+{%- if config_item == 'threads' %}
 {{ config_item }}={{ value | string }}
 {%- elif value == True %}
 {{ config_item }}=yes

--- a/templates/recursor.conf.j2
+++ b/templates/recursor.conf.j2
@@ -4,7 +4,9 @@ setgid={{ pdns_rec_group }}
 
 {% for config_item, value in pdns_rec_config.items() | sort() %}
 {% if config_item not in ["config-dir", "setuid", "setgid"] %}
-{% if value == True %}
+{%- if config_item == 'threads' %}
+{{ config_item }}={{ value | string }}
+{%- elif value == True %}
 {{ config_item }}=yes
 {% elif value == False %}
 {{ config_item }}=no


### PR DESCRIPTION
`threads` variable works well when set to the number of vcpus on a system.  However, if using a small/test system, this might be "1".  With the existing template, this sets `threads` to `yes` instead of `1`, and pdns-recursor won't start.

With the change, `threads` is set to the string of whatever the variable is set to, and other variabes are handled in the same manner as before.

There are other ways to accomplish this, but it is the only case  I know of with the pdns-recursor role, so this is an easy fix and might not need to be more complicated.