### PR TITLE
Allow to optionally disable handlers execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.1.0 (Unreleased)
+
+NEW FEATURES:
+- Add an option (`pdns_rec_disable_handlers`) to disable the automated restart of the service on configuration changes ([\#41](https://github.com/PowerDNS/pdns_recursor-ansible/pull/41))
+
 ## v1.0.0 (2018-07-13)
 
 __BREAKING CHANGES__:
@@ -5,25 +10,25 @@ __BREAKING CHANGES__:
 - Rename the `pdns_rec_lua_dns_script_content` to `pdns_rec_config_lua_dns_script_file_content`
 
 NEW FEATURES:
-- Continuos testing with molecule 2.14.0 ([\#39](https://github.com/PowerDNS/pdns-ansible/pull/39))
-- Install debuginfo packages ([\#38](https://github.com/PowerDNS/pdns-ansible/pull/38))
-- Allow to manage systemd overrides ([\#37](https://github.com/PowerDNS/pdns-ansible/pull/37))
+- Continuos testing with molecule 2.14.0 ([\#39](https://github.com/PowerDNS/pdns_recursor-ansible/pull/39))
+- Install debuginfo packages ([\#38](https://github.com/PowerDNS/pdns_recursor-ansible/pull/38))
+- Allow to manage systemd overrides ([\#37](https://github.com/PowerDNS/pdns_recursor-ansible/pull/37))
 
 IMPROVEMENTS:
-- Improved documentation ([\#39](https://github.com/PowerDNS/pdns-ansible/pull/39))
+- Improved documentation ([\#39](https://github.com/PowerDNS/pdns_recursor-ansible/pull/39))
 
 BUG FIXES:
-- Fix the examples in the README file ([\#31](https://github.com/PowerDNS/pdns-ansible/pull/31))
-- Handle different version string for Debian and CentOS ([\#30](https://github.com/PowerDNS/pdns-ansible/pull/30))
+- Fix the examples in the README file ([\#31](https://github.com/PowerDNS/pdns_recursor-ansible/pull/31))
+- Handle different version string for Debian and CentOS ([\#30](https://github.com/PowerDNS/pdns_recursor-ansible/pull/30))
 
 ## v0.1.1 (2017-09-29)
 
 NEW FEATURES:
-- Install specific PowerDNS Recursor versions ([\#29](https://github.com/PowerDNS/pdns-ansible/pull/29))
+- Install specific PowerDNS Recursor versions ([\#29](https://github.com/PowerDNS/pdns_recursor-ansible/pull/29))
 
 IMPROVEMENTS:
-- Add support to the PowerDNS Recursor 4.1.x releases ([\#28](https://github.com/PowerDNS/pdns-ansible/pull/28))
-- Fixing minor linter issues with whitespace ([\#30](https://github.com/PowerDNS/pdns-ansible/pull/30))
+- Add support to the PowerDNS Recursor 4.1.x releases ([\#28](https://github.com/PowerDNS/pdns_recursor-ansible/pull/28))
+- Fixing minor linter issues with whitespace ([\#30](https://github.com/PowerDNS/pdns_recursor-ansible/pull/30))
 
 BUG FIXES:
 - Handle correctly the `include-dir` configuration setting when defined
@@ -36,5 +41,5 @@ NEW FEATURES:
 - PowerDNS Recursor installation and configuration with Red-Hat and Debian support
 
 IMPROVEMENTS:
-- Switch to the MIT License ([\#27](https://github.com/PowerDNS/pdns-ansible/pull/27))
-- Overall role refactoring ([\#19](https://github.com/PowerDNS/pdns-ansible/pull/19))
+- Switch to the MIT License ([\#27](https://github.com/PowerDNS/pdns_recursor-ansible/pull/27))
+- Overall role refactoring ([\#19](https://github.com/PowerDNS/pdns_recursor-ansible/pull/19))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v1.1.0 (Unreleased)
 
 NEW FEATURES:
-- Add an option (`pdns_rec_disable_handlers`) to disable the automated restart of the service on configuration changes ([\#41](https://github.com/PowerDNS/pdns_recursor-ansible/pull/41))
+- Add an option (`pdns_rec_disable_handlers`) to disable the automated restart of the service on configuration changes ([\#43](https://github.com/PowerDNS/pdns_recursor-ansible/pull/43))
 
 ## v1.0.0 (2018-07-13)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Force the execution of the flushing of the handlers at the end of the role. <br 
 **NOTE:** This is required if using this role to configure multiple recursor instances in a single play
 
 ```yaml
+pdns_rec_disable_handlers: False
+```
+
+Disable automated service restart on configuration changes.
+
+```yaml
 pdns_rec_config_dir: "/etc/powerdns"
 pdns_rec_config_file: "recursor.conf"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,9 @@ pdns_rec_service_name: "pdns-recursor"
 # instance is restarted.
 pdns_rec_flush_handlers: False
 
+# When True, disable the automated restart of the PowerDNS Recursor service
+pdns_rec_disable_handlers: False
+
 # Configuration directory and files
 pdns_rec_config_dir: "{{ default_pdns_rec_config_dir }}"
 pdns_rec_config_file: "recursor.conf"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,10 @@
   service:
     name: "{{ pdns_rec_service_name }}"
     state: restarted
-    sleep: 1  # the sleep is needed to make sure the service has been
-    # correctly started after being stopped during restarts
+    sleep: 1                           # the sleep is needed to make sure the service has been
+  when: not pdns_rec_disable_handlers  # correctly started after being stopped during restarts
 
 - name: reload systemd and restart PowerDNS Recursor
   command: systemctl daemon-reload
   notify: restart PowerDNS Recursor
+  when: not pdns_rec_disable_handlers


### PR DESCRIPTION
This PR adds the `pdns_rec_disable_handlers` variable to optionally disable handlers execution on configuration changes.