### PR TITLE
 Disable rights change for pdns config dir

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,6 @@
       owner: root
       group: root
     notify: reload systemd and restart PowerDNS Recursor
-
   when: pdns_rec_service_overrides != {}
     and ansible_service_mgr == "systemd"
 
@@ -24,9 +23,6 @@
   file:
     name: "{{ pdns_rec_config_dir }}"
     state: directory
-    owner: root
-    group: root
-    mode: 0750
 
 - name: Generate the PowerDNS Recursor configuration
   template:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,13 +24,16 @@
   file:
     name: "{{ pdns_rec_config_dir }}"
     state: directory
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Generate the PowerDNS Recursor configuration
   template:
     src: recursor.conf.j2
     dest: "{{ pdns_rec_config_dir }}/{{ pdns_rec_config_file }}"
     owner: "root"
-    group: "root"
+    group: "{{ pdns_rec_group }}"
     mode: 0640
   notify: restart PowerDNS Recursor
 
@@ -48,7 +51,7 @@
     dest: "{{ pdns_rec_config_lua }}"
     content: "{{ pdns_rec_config_lua_file_content }}"
     owner: "root"
-    group: "root"
+    group: "{{ pdns_rec_group }}"
     mode: 0640
   notify: restart PowerDNS Recursor
   when: pdns_rec_config_lua_file_content != ""
@@ -58,7 +61,7 @@
     dest: "{{ pdns_rec_config_dns_script }}"
     content: "{{ pdns_rec_config_dns_script_file_content }}"
     owner: "root"
-    group: "root"
+    group: "{{ pdns_rec_group }}"
     mode: 0640
   notify: restart PowerDNS Recursor
   when: pdns_rec_config_dns_script_file_content != ""

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,7 @@
       owner: root
       group: root
     notify: reload systemd and restart PowerDNS Recursor
+
   when: pdns_rec_service_overrides != {}
     and ansible_service_mgr == "systemd"
 


### PR DESCRIPTION
Do not touch right for powerdns config and leave it as in package. Because of 750 (default is 755) I unable to place additional configuration files in config directory.