### PR TITLE
Add some variables to allow to configure the status of the Recursor service

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Force the execution of the flushing of the handlers at the end of the role. <br 
 **NOTE:** This is required if using this role to configure multiple recursor instances in a single play
 
 ```yaml
+pdns_rec_service_state: "started"
+pdns_rec_service_enabled: "yes"
+```
+
+Allow to specify the desired state of the PowerDNS Recursor service.
+E.g. This allows to install and configure the PowerDNS Recursor without automatically starting the service.
+
+```yaml
 pdns_rec_disable_handlers: False
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,10 @@ pdns_rec_service_name: "pdns-recursor"
 # instance is restarted.
 pdns_rec_flush_handlers: False
 
+# State of the PowerDNS Recursor service
+pdns_rec_service_state: "started"
+pdns_rec_service_enabled: "yes"
+
 # When True, disable the automated restart of the PowerDNS Recursor service
 pdns_rec_disable_handlers: False
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,9 @@
     name: "{{ pdns_rec_service_name }}"
     state: restarted
     sleep: 1                           # the sleep is needed to make sure the service has been
-  when: not pdns_rec_disable_handlers  # correctly started after being stopped during restarts
+                                       # correctly started after being stopped during restarts
+  when: pdns_rec_service_state != 'stopped' and
+    not pdns_rec_disable_handlers
 
 - name: reload systemd and restart PowerDNS Recursor
   command: systemctl daemon-reload

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,14 @@
 ---
 
+# The sleep in the restart "PowerDNS Recursor handler"
+# is needed to make sure to start correctly the service
+# after stopping it during restarts
+
 - name: restart PowerDNS Recursor
   service:
     name: "{{ pdns_rec_service_name }}"
     state: restarted
-    sleep: 1                           # the sleep is needed to make sure the service has been
-                                       # correctly started after being stopped during restarts
+    sleep: 1
   when: pdns_rec_service_state != 'stopped' and
     not pdns_rec_disable_handlers
 

--- a/molecule/pdns-rec-41/molecule.yml
+++ b/molecule/pdns-rec-41/molecule.yml
@@ -27,11 +27,6 @@ platforms:
     groups:
       - pdns-rec
 
-  - name: ubuntu-1710
-    image: ubuntu:17.10
-    groups:
-      - pdns-rec
-
   - name: ubuntu-1804
     image: ubuntu:18.04
     groups:

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -27,11 +27,6 @@ platforms:
     groups:
       - pdns-rec
 
-  - name: ubuntu-1710
-    image: ubuntu:17.10
-    groups:
-      - pdns-rec
-
   - name: ubuntu-1804
     image: ubuntu:18.04
     groups:

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -22,14 +22,14 @@
 
     - name: Discover local Docker images
       docker_image_facts:
-        name: "molecule_pdns/{{ item.item.name }}"
+        name: "molecule_pdns_rec/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
       docker_image:
         path: "{{ molecule_ephemeral_directory }}"
-        name: "molecule_pdns/{{ item.item.image }}"
+        name: "molecule_pdns_rec/{{ item.item.image }}"
         dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
         force: "{{ item.item.force | default(True) }}"
       with_items: "{{ platforms.results }}"
@@ -51,7 +51,7 @@
       docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
-        image: "molecule_pdns/{{ item.image }}"
+        image: "molecule_pdns_rec/{{ item.image }}"
         links: "{{ molecule_service_instances | map(attribute='name') | list }}"
         command: "{{ item.command | default(omit) }}"
         state: started

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -59,7 +59,7 @@
 - name: Generate PowerDNS Recursor Lua dns-script
   copy:
     dest: "{{ pdns_rec_config_dns_script }}"
-    content: "{{ }}"
+    content: "{{ pdns_rec_config_dns_script_file_content }}"
     owner: "root"
     group: "root"
     mode: 0640

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,19 +2,19 @@
 
 - block:
 
-  - name: Prefix the version with the correct separator on RedHat
+  - name: Prefix the version of the PowerDNS Recursor package with the correct separator on RedHat
     set_fact:
       _pdns_rec_package_version: "-{{ pdns_rec_package_version }}"
     when: ansible_os_family == 'RedHat'
 
-  - name: Prefix the version with the correct separator on Debian
+  - name: Prefix the version of the PowerDNS Recursor package with the correct separator on Debian
     set_fact:
       _pdns_rec_package_version: "={{ pdns_rec_package_version }}"
     when: ansible_os_family == 'Debian'
 
   when: pdns_rec_package_version != ''
 
-- name: Install PowerDNS
+- name: Install the PowerDNS Recursor
   package:
     name: "{{ pdns_rec_package_name }}{{ _pdns_rec_package_version | default('') }}"
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,11 @@
   tags:
     - config
 
-- name: Start and enable the PowerDNS Recursor service
+- name: Set the status of the PowerDNS Recursor service
   service:
     name: "{{ pdns_rec_service_name }}"
-    state: started
-    enabled: true
+    state: "{{ pdns_rec_service_state }}"
+    enabled: "{{ pdns_rec_service_enabled }}"
   tags:
     - service
 


### PR DESCRIPTION
This PR introduces to new variables `pdns_rec_service_state` and `pdns_rec_service_enabled` to configure the status of the PowerDNS Recursor service.

A typical use-case is the installation of the PowerDNS Recursor without actually starting the service automatically via Ansible.