### PR TITLE
Update the molecule test-suite to test against Ansible 2.5, 2.6 and 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ services:
 # Ansible versions
 env:
   matrix:
-    - ANSIBLE=2.2
-    - ANSIBLE=2.3
-    - ANSIBLE=2.4
     - ANSIBLE=2.5
+    - ANSIBLE=2.6
+    - ANSIBLE=2.7
 
 # Install tox
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ ANSIBLE=
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible25: ansible<2.5
-    ansible26: ansible<2.6
-    ansible27: ansible<2.7
+    ansible25: ansible<2.6
+    ansible26: ansible<2.7
+    ansible27: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,16 @@ skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.2: ansible22
-  2.3: ansible23
-  2.4: ansible24
   2.5: ansible25
+  2.6: ansible26
+  2.7: ansible27
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible22: ansible<2.3
-    ansible23: ansible<2.4
-    ansible24: ansible<2.5
-    ansible25: ansible<2.6
+    ansible25: ansible<2.5
+    ansible26: ansible<2.6
+    ansible27: ansible<2.7
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{22,23,24,25}
+envlist = py{27}-ansible{25,26,27}
 skipsdist = true
 
 [travis:env]


### PR DESCRIPTION
This PR updates the test-suite to test against more recent versions of Ansible.