### PR TITLE
Update the CI to test against more recent Ansible/Python/OS versions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Ansible ###
 *.retry
+.ansible_cache
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 
 language: python
-python: 2.7
+python:
+  - "2.7"
+  - "3.6"
 
 sudo: required
 
@@ -9,13 +11,21 @@ sudo: required
 services:
   - docker
 
+# Replace aufs with the vfs docker storage driver
+# to prevent systemd to fail starting docker in docker.
+before_install:
+  - sudo sed -i 's|DOCKER_OPTS=.*|DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock --storage-driver vfs"|g' /etc/default/docker
+  - sudo service docker restart
+  - docker info
+
 # Parallel testing of the supported
 # Ansible versions
 env:
   matrix:
-    - ANSIBLE=2.5
     - ANSIBLE=2.6
     - ANSIBLE=2.7
+    - ANSIBLE=2.8
+    - ANSIBLE=2.9
 
 # Install tox
 install:
@@ -23,7 +33,7 @@ install:
 
 # Test the current PowerDNS Recursor stable release
 script:
-  - tox -- molecule test -s pdns-rec-41
+  - tox -- molecule test -s pdns-rec-42
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
 # Ansible versions
 env:
   matrix:
-    - ANSIBLE=2.6
     - ANSIBLE=2.7
     - ANSIBLE=2.8
     - ANSIBLE=2.9

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ To test all the scenarios run
 
 To run a custom molecule command
 
-    $ tox -e py27-ansible22 -- molecule test -s pdns-rec-41
+    $ tox -e py27-ansible22 -- molecule test -s pdns-rec-42
 
 ## License
 

--- a/molecule/pdns-rec-42/molecule.yml
+++ b/molecule/pdns-rec-42/molecule.yml
@@ -17,9 +17,11 @@ platforms:
     image: centos:7
     dockerfile_tpl: centos-systemd
 
-  - name: centos-8
-    image: centos:8
-    dockerfile_tpl: centos-systemd
+  # Temporarely disable CentOS 8 due to:
+  # https://github.com/ansible/ansible/issues/64963
+  # - name: centos-8
+  #   image: centos:8
+  #   dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
@@ -38,6 +40,14 @@ provisioner:
   options:
     diff: True
     v: True
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: .ansible_cache
+      fact_caching_timeout: 7200
+    ssh_connection:
+      pipelining: true
   inventory:
     links:
       host_vars: ../resources/host_vars/

--- a/molecule/pdns-rec-42/molecule.yml
+++ b/molecule/pdns-rec-42/molecule.yml
@@ -38,6 +38,9 @@ provisioner:
   options:
     diff: True
     v: True
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml

--- a/molecule/pdns-rec-42/molecule.yml
+++ b/molecule/pdns-rec-42/molecule.yml
@@ -1,7 +1,7 @@
 ---
 
 scenario:
-  name: pdns-rec-41
+  name: pdns-rec-42
 
 driver:
   name: docker
@@ -12,35 +12,26 @@ dependency:
 platforms:
   - name: centos-6
     image: centos:6
-    groups:
-      - pdns-rec
 
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - pdns-rec
 
-  - name: ubuntu-1604
-    image: ubuntu:16.04
-    dockerfile_tpl: debian-systemd
-    groups:
-      - pdns-rec
+  - name: centos-8
+    image: centos:8
+    dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
-    groups:
-      - pdns-rec
-
-  - name: debian-8
-    image: debian:8
-    groups:
-      - pdns-rec
+    dockerfile_tpl: debian-systemd
 
   - name: debian-9
     image: debian:9
-    groups:
-      - pdns-rec
+    dockerfile_tpl: debian-systemd
+
+  - name: debian-10
+    image: debian:10
+    dockerfile_tpl: debian-systemd
 
 provisioner:
   name: ansible
@@ -66,11 +57,10 @@ lint:
 verifier:
   name: testinfra
   options:
-    hosts: pdns-rec
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
-    # path relative to 'directory'
-    - ../repo-41/
+    # path relative to '../resources/tests/all'
+    - ../repo-42/
   lint:
     name: flake8

--- a/molecule/pdns-rec-42/playbook.yml
+++ b/molecule/pdns-rec-42/playbook.yml
@@ -1,8 +1,8 @@
 ---
 
-- hosts: pdns-rec
+- hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
-    - ../resources/vars/pdns-rec-repo-41.yml
+    - ../resources/vars/pdns-rec-repo-42.yml
   roles:
     - { role: pdns_recursor-ansible }

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -17,9 +17,11 @@ platforms:
     image: centos:7
     dockerfile_tpl: centos-systemd
 
-  - name: centos-8
-    image: centos:8
-    dockerfile_tpl: centos-systemd
+  # Temporarely disable CentOS 8 due to:
+  # https://github.com/ansible/ansible/issues/64963
+  # - name: centos-8
+  #   image: centos:8
+  #   dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
@@ -38,6 +40,17 @@ provisioner:
   options:
     diff: True
     v: True
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: .ansible_cache
+      fact_caching_timeout: 7200
+    ssh_connection:
+      pipelining: true
+  inventory:
+    links:
+      host_vars: ../resources/host_vars/
   playbooks:
     create: ../resources/create.yml
     destroy: ../resources/destroy.yml

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -23,12 +23,15 @@ platforms:
 
   - name: ubuntu-1804
     image: ubuntu:18.04
+    dockerfile_tpl: debian-systemd
 
   - name: debian-9
     image: debian:9
+    dockerfile_tpl: debian-systemd
 
   - name: debian-10
     image: debian:10
+    dockerfile_tpl: debian-systemd
 
 provisioner:
   name: ansible

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -12,35 +12,23 @@ dependency:
 platforms:
   - name: centos-6
     image: centos:6
-    groups:
-      - pdns-rec
 
   - name: centos-7
     image: centos:7
     dockerfile_tpl: centos-systemd
-    groups:
-      - pdns-rec
 
-  - name: ubuntu-1604
-    image: ubuntu:16.04
-    dockerfile_tpl: debian-systemd
-    groups:
-      - pdns-rec
+  - name: centos-8
+    image: centos:8
+    dockerfile_tpl: centos-systemd
 
   - name: ubuntu-1804
     image: ubuntu:18.04
-    groups:
-      - pdns-rec
-
-  - name: debian-8
-    image: debian:8
-    groups:
-      - pdns-rec
 
   - name: debian-9
     image: debian:9
-    groups:
-      - pdns-rec
+
+  - name: debian-10
+    image: debian:10
 
 provisioner:
   name: ansible
@@ -66,11 +54,10 @@ lint:
 verifier:
   name: testinfra
   options:
-    hosts: pdns-rec
     vvv: True
   directory: ../resources/tests/all
   additional_files_or_dirs:
-    # path relative to 'directory'
+    # path relative to '../resources/tests/all'
     - ../repo-master/
   lint:
     name: flake8

--- a/molecule/pdns-rec-master/playbook.yml
+++ b/molecule/pdns-rec-master/playbook.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: pdns-rec
+- hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-master.yml

--- a/molecule/resources/Dockerfile.centos-systemd.j2
+++ b/molecule/resources/Dockerfile.centos-systemd.j2
@@ -22,5 +22,6 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/usr/sbin/init"]
 
-RUN if [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf net-tools bash && dnf clean all; \
+RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python3-dnf python3-pip bash iproute && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl net-tools bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; fi

--- a/molecule/resources/Dockerfile.centos-systemd.j2
+++ b/molecule/resources/Dockerfile.centos-systemd.j2
@@ -22,6 +22,6 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/usr/sbin/init"]
 
-RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python3-dnf python3-pip bash iproute && dnf clean all; \
+RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl net-tools bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; fi

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -21,18 +21,17 @@
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_info:
+      docker_image_facts:
         name: "molecule_pdns_rec/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
       docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_pdns_rec/{{ item.item.image }}"
-        build.path: "{{ molecule_ephemeral_directory }}"
-        build.dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
-        force_source: "{{ item.item.force | default(True) }}"
-        force_tag: "{{ item.item.force | default(True) }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(True) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -21,17 +21,18 @@
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_facts:
+      docker_image_info:
         name: "molecule_pdns_rec/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
       docker_image:
-        path: "{{ molecule_ephemeral_directory }}"
         name: "molecule_pdns_rec/{{ item.item.image }}"
-        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
-        force: "{{ item.item.force | default(True) }}"
+        build.path: "{{ molecule_ephemeral_directory }}"
+        build.dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force_source: "{{ item.item.force | default(True) }}"
+        force_tag: "{{ item.item.force | default(True) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 

--- a/molecule/resources/host_vars/centos-8.yml
+++ b/molecule/resources/host_vars/centos-8.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_python_interpreter: "/usr/bin/python3"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Prepare the Molecule Test Resources
-  hosts: pdns-rec
+  hosts: all
   tasks:
     # Install rsyslog to capture the PowerDNS Recursor log messages
     # when the service is not managed by systemd

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -87,4 +87,4 @@ def systemd_override(host):
         assert f.exists
         assert f.user == 'root'
         assert f.group == 'root'
-        assert 'LimitCORE=infinity' in f.content
+        assert f.contains('LimitCORE=infinity')

--- a/molecule/resources/tests/repo-42/test_repo_42.py
+++ b/molecule/resources/tests/repo-42/test_repo_42.py
@@ -6,9 +6,9 @@ rhel_os = ['redhat', 'centos']
 def test_repo_file(host):
     f = None
     if host.system_info.distribution.lower() in debian_os:
-        f = host.file('/etc/apt/sources.list.d/powerdns-rec-41.list')
+        f = host.file('/etc/apt/sources.list.d/powerdns-rec-42.list')
     if host.system_info.distribution.lower() in rhel_os:
-        f = host.file('/etc/yum.repos.d/powerdns-rec-41.repo')
+        f = host.file('/etc/yum.repos.d/powerdns-rec-42.repo')
 
     assert f.exists
     assert f.user == 'root'
@@ -18,15 +18,15 @@ def test_repo_file(host):
 def test_pdns_repo(host):
     f = None
     if host.system_info.distribution.lower() in debian_os:
-        f = host.file('/etc/apt/sources.list.d/powerdns-rec-41.list')
+        f = host.file('/etc/apt/sources.list.d/powerdns-rec-42.list')
     if host.system_info.distribution.lower() in rhel_os:
-        f = host.file('/etc/yum.repos.d/powerdns-rec-41.repo')
+        f = host.file('/etc/yum.repos.d/powerdns-rec-42.repo')
 
     assert f.exists
-    assert f.contains('rec-41')
+    assert f.contains('rec-42')
 
 
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_recursor --version')
 
-    assert 'PowerDNS Recursor 4.1.' in cmd.stderr
+    assert 'PowerDNS Recursor 4.2.' in cmd.stderr

--- a/molecule/resources/tests/repo-42/test_repo_42.py
+++ b/molecule/resources/tests/repo-42/test_repo_42.py
@@ -29,4 +29,5 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_recursor --version')
 
-    assert 'PowerDNS Recursor 4.2.' in cmd.stderr
+    assert 'PowerDNS Recursor' in cmd.stderr
+    assert '4.2' in cmd.stderr

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -29,4 +29,5 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_recursor --version')
 
-    assert 'PowerDNS Recursor 0.0.' in cmd.stderr
+    assert 'PowerDNS Recursor' in cmd.stderr
+    assert 'master' in cmd.stderr

--- a/molecule/resources/vars/pdns-rec-repo-41.yml
+++ b/molecule/resources/vars/pdns-rec-repo-41.yml
@@ -1,7 +1,0 @@
----
-
-##
-# PowerDNS Recursor 4.1.x Repository
-##
-
-pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_41 }}"

--- a/molecule/resources/vars/pdns-rec-repo-42.yml
+++ b/molecule/resources/vars/pdns-rec-repo-42.yml
@@ -1,0 +1,7 @@
+---
+
+##
+# PowerDNS Recursor 4.2.x Repository
+##
+
+pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_42 }}"

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -21,6 +21,7 @@
     name: yum-plugin-priorities
     state: present
   when: ansible_distribution in [ 'CentOS' ]
+    and ansible_pkg_mgr in [ 'yum' ]
 
 - name: Add the PowerDNS Recursor YUM Repository
   yum_repository:
@@ -30,7 +31,7 @@
     baseurl: "{{ pdns_rec_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ pdns_rec_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
 
 - name: Add the PowerDNS Recursor debug symbols YUM Repository
@@ -41,6 +42,6 @@
     baseurl: "{{ pdns_rec_install_repo['yum_debug_symbols_repo_baseurl'] }}"
     gpgkey: "{{ pdns_rec_install_repo['gpg_key'] }}"
     gpgcheck: yes
-    priority: 90
+    priority: "90"
     state: present
   when: pdns_rec_install_debug_symbols_package

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -3,13 +3,13 @@
 - block:
 
   - name: Install epel-release on CentOS
-    yum:
+    package:
       name: epel-release
       state: present
     when: ansible_distribution in [ 'CentOS' ]
 
   - name: Install epel-release on RHEL/OracleLinux
-    yum:
+    package:
       name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
       state: present
     when: ansible_distribution in [ 'RedHat', 'OracleLinux' ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,22 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{25,26,27}
+envlist = py{27,36}-ansible{26,27,28,29}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.5: ansible25
   2.6: ansible26
   2.7: ansible27
+  2.8: ansible28
+  2.9: ansible29
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible25: ansible<2.6
     ansible26: ansible<2.7
     ansible27: ansible<2.8
+    ansible28: ansible<2.9
+    ansible29: ansible<2.10
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 minversion = 1.8
-envlist = py{27,36}-ansible{26,27,28,29}
+envlist = py{27,36}-ansible{27,28,29}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.6: ansible26
   2.7: ansible27
   2.8: ansible28
   2.9: ansible29
@@ -14,7 +13,6 @@ ANSIBLE=
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible26: ansible<2.7
     ansible27: ansible<2.8
     ansible28: ansible<2.9
     ansible29: ansible<2.10


### PR DESCRIPTION
This PR implements multiple enhancements to the versions of the software used by the Travis CI infrastructure:

- add Python 3 to the tests matrix
- add Ansible 2.8 and Ansible 2.9 to the tests matrix
- remove Ansible 2.5 and Ansible 2.6 from the tests matrix (as these are unmaintained and eol)
- ~add CentOS 8 as test target~
- update the testinfra code to test against the 4.2.0 release of the PowerDNS Recursor
- speedup the tests execution enabling Ansible cache and pipelining