### PR TITLE
Make sure to restart the Recursor on systemd-unit changes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -78,6 +78,7 @@
     sleep: 1
   when: not pdns_rec_disable_handlers
     and pdns_rec_service_state != 'stopped'
-    and (_pdns_recursor_configuration.changed
+    and (_pdns_recursor_override_unit.changed
+      or _pdns_recursor_configuration.changed
       or _pdns_recursor_lua_file_configuraton.changed
       or _pdns_recursor_dns_script_configuration.changed)


### PR DESCRIPTION
As per the title, this PR ensures that the Recursor is restarted on changes to the systemd unit overrides.