### PR TITLE
Fix the default pdns_rec_service_overrides to work with the Recursor 4.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ the content of this variable to the `pdns_rec_config_dns_script` file and
 define accordingly the `lua-dns-script` setting in the `recursor.conf` configuration file.
 
 ```yaml
-pdns_rec_service_overrides: {}
+pdns_rec_service_overrides:
+  User: "{{ pdns_rec_user }}"
+  Group: "{{ pdns_rec_group }}"
 ```
 
 Dict with overrides for the service (systemd only).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,8 @@ pdns_rec_config: {}
 #  server-id: 'nothing to see here'
 
 # Dict with overrides for the service (systemd only)
-pdns_rec_service_overrides: {}
+pdns_rec_service_overrides:
+  User: "{{ pdns_rec_user }}"
+  Group: "{{ pdns_rec_group }}"
 # pdns_rec_service_overrides:
 #   LimitNOFILE: 10000

--- a/molecule/pdns-rec-42/molecule.yml
+++ b/molecule/pdns-rec-42/molecule.yml
@@ -17,8 +17,6 @@ platforms:
     image: centos:7
     dockerfile_tpl: centos-systemd
 
-  # Temporarely disable CentOS 8 due to:
-  # https://github.com/ansible/ansible/issues/64963
   # - name: centos-8
   #   image: centos:8
   #   dockerfile_tpl: centos-systemd


### PR DESCRIPTION
Make sure to configure the User and Group in systemd to install correctly the Recursor 4.3