### PR TITLE
Use HTTPs everywhere to connect to the PowerDNS repositories

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -5,6 +5,11 @@
     name: gnupg
     state: present
 
+- name: Install apt-transport-https
+  package:
+    name: apt-transport-https
+    state: present
+
 - name: Import the PowerDNS Recursor APT Repository key
   apt_key:
     url: "{{ pdns_rec_install_repo['gpg_key'] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,8 +4,8 @@ default_pdns_rec_package_name: "pdns-recursor"
 
 pdns_rec_powerdns_repo_master:
   apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-master main"
-  gpg_key: "http://repo.powerdns.com/CBC8B383-pub.asc"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-master main"
+  gpg_key: "https://repo.powerdns.com/CBC8B383-pub.asc"
   gpg_key_id: "D47975F8DAE32700A563E64FFF389421CBC8B383"
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-master"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-master/debug"
@@ -13,8 +13,8 @@ pdns_rec_powerdns_repo_master:
 
 pdns_rec_powerdns_repo_40:
   apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-40 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-40 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
   gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-40"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-40/debug"
@@ -22,8 +22,8 @@ pdns_rec_powerdns_repo_40:
 
 pdns_rec_powerdns_repo_41:
   apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-41 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-41 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
   gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-41"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-41/debug"
@@ -31,8 +31,8 @@ pdns_rec_powerdns_repo_41:
 
 pdns_rec_powerdns_repo_42:
   apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-42 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-42 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
   gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-42"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-42/debug"
@@ -40,8 +40,8 @@ pdns_rec_powerdns_repo_42:
 
 pdns_rec_powerdns_repo_43:
   apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] http://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-43 main"
-  gpg_key: "http://repo.powerdns.com/FD380FBB-pub.asc"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-43 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
   gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-43"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-43/debug"


### PR DESCRIPTION
Switch to HTTPS for the PowerDNS repositories configuration.