### PR TITLE
Check pdns version in systemd unit override definition.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,8 @@ pdns_rec_group: "{{ default_pdns_rec_group }}"
 
 # Name of the PowerDNS Service
 pdns_rec_service_name: "pdns-recursor"
+# Name of the PowerDNS binary.
+pdns_rec_bin_name: "pdns_recursor"
 
 # State of the PowerDNS Recursor service
 pdns_rec_service_state: "started"
@@ -82,8 +84,4 @@ pdns_rec_config: {}
 #  server-id: 'nothing to see here'
 
 # Dict with overrides for the service (systemd only)
-pdns_rec_service_overrides:
-  User: "{{ pdns_rec_user }}"
-  Group: "{{ pdns_rec_group }}"
-# pdns_rec_service_overrides:
-#   LimitNOFILE: 10000
+pdns_rec_service_overrides: "{{ default_pdns_rec_service_overrides }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,7 +23,6 @@
       and _pdns_recursor_override_unit.changed
 
   when: ansible_service_mgr == "systemd"
-    and pdns_rec_service_overrides != {}
 
 - name: Ensure that the PowerDNS Recursor configuration directory exists
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,3 +24,22 @@
     name: "{{ pdns_rec_debug_symbols_package_name }}{{ _pdns_rec_package_version | default('') }}"
     state: present
   when: pdns_rec_install_debug_symbols_package
+
+- block:
+  - name: Obtain pdns version string
+    command:
+      argv:
+        - "{{ pdns_rec_bin_name }}"
+        - '--version'
+    register: pdns_rec_ver_output
+    changed_when: false
+    when: pdns_rec_package_version | length == 0
+
+  - name: Set pdns version
+    set_fact:
+      _pdns_rec_version: >-
+        {{ pdns_rec_ver_output.stderr_lines[0]
+              | regex_search("(?<=PowerDNS Recursor )[0-9.]+(?= )")
+            if pdns_rec_package_version | length == 0
+            else pdns_rec_package_version
+        }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,3 +46,10 @@ pdns_rec_powerdns_repo_43:
   yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-43"
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-43/debug"
   name: "powerdns-rec-43"
+
+default_pdns_rec_service_overrides: >-
+  {{  { 'User'  : pdns_rec_user
+      , 'Group' : pdns_rec_group
+      } if _pdns_rec_version is version('4.3', operator='ge')
+        else {}
+  }}


### PR DESCRIPTION
Hi.

This is proof-of-concept fix for #58 .  At least, it should be decided, whether it's fine to raise ansible min version to 2.5 or not, and either replace `pdns_recursor --version` call with `package_facts` module or fix somehow different names for `version_compare` test.

If it's fine to raise min ansible version to 2.5, then:
- we may use `package_facts` module to obtain pdns version, after it has been installed.
- then compare it with 4.3 using `version` test (no problems with test name).

If it's better to preserve 2.2 min ansible version, then:
- we may just call `pdns_recursor --version` and parse version from first string. Though, we need to know pdns binary name for this. (here this method is implemented)
- we'll most likely have trouble with `version` test, which was named `version_compare` before 2.5. On ansible 2.7 the old name no longer works, other versions i didn't try.