### PR TITLE
Add support for other OS with default values (can be overwritten by t…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 
 - name: Include OS-specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}.yml"
+    - Other.yml
   tags:
     - always
 

--- a/vars/Other.yml
+++ b/vars/Other.yml
@@ -1,0 +1,6 @@
+---
+
+default_pdns_rec_user: "pdns"
+default_pdns_rec_group: "pdns"
+default_pdns_rec_config_dir: "/etc/powerdns"
+default_pdns_recorsor_debug_symbols_package_name: "pdns-recursor-dbg"


### PR DESCRIPTION
### Add support for other OS with default values (can be overwritten by the user)

Hello,

If a user try to use the role on other OS than Debian or RedHat families, this will fail even if he modified the variables in the group_vars (for example) for his OS.

Example of error with Gentoo OS:
```
TASK [powerdns.pdns_recursor : Include OS-specific variables] *******************************************************************************************************************************
fatal: [resolver02.wirebrass.fr]: FAILED! => {"ansible_facts": {}, "ansible_included_var_files": [], "changed": false, "message": "Could not find or access 'Gentoo.yml'\nSearched in:\n\t/ho
me/john/ansible-base/roles/powerdns.pdns_recursor/vars/Gentoo.yml\n\t/home/john/ansible-base/roles/powerdns.pdns_recursor/Gentoo.yml\n\t/home/john/ansible-base/roles/powerdns.pdns_recursor$
tasks/vars/Gentoo.yml\n\t/home/john/ansible-base/roles/powerdns.pdns_recursor/tasks/Gentoo.yml\n\t/home/john/ansible-base/vars/Gentoo.yml\n\t/home/john/ansible-base/Gentoo.yml on the Ansib$
e Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```

So, I suggest to add and "Other" vars file which will only be included if no other matching vars has been found (ex : Debian.yml or RedHat.yml).

This allow any user from any OS to use the role. In some case he may just need to adjust some vars in his group_vars or host_vars but there will be no more blocking error (even if he has adjusted the variables).

Do not hesitate if you have a question or comments.

Have a nice day