### PR TITLE
Fixes #70 Role fails to run in check mode.

### DIFF
--- a/tasks/install-Linux.yml
+++ b/tasks/install-Linux.yml
@@ -35,3 +35,5 @@
     - name: Set pdns version
       set_fact:
         _pdns_rec_version: "{{ _pdns_rec_ver_output['stdout'] | regex_replace('-[.\\d\\w]+$', '') }}"
+      when: not ansible_check_mode
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -44,3 +44,7 @@ default_pdns_rec_service_overrides: >-
       } if _pdns_rec_version is version('4.3', operator='ge')
         else {}
   }}
+
+# Default value intended to be used during check mode, when proper version
+# detection does not run.
+_pdns_rec_version: "{{ pdns_rec_package_version if pdns_rec_package_version != '' else 0 }}"


### PR DESCRIPTION
Hi.

This is the fix for check mode.

I can't make fix suggested by @Qwiz in #70 (add `check_mode: no` to `Obtain pdns version string` task) working, because version detection relies on the fact, that `pdns_recursor` is indeed installed. But when run in check mode, this may not be the case. Moreover, using 'shell' in `Obtain pdns version string` task hides this fact, because pipeline always has return code of last command (which is `awk`) and `awk` will never fail here. But that's (probably) another problem.

So, i've just added default value of 0 for `_pdns_rec_version`, which may not show accurate results in some cases (when we need to modify systemd override file), but at least make check mode run till the end.