### PR TITLE
added 4.6.x and 4.7.x release train repositories

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -38,6 +38,25 @@ pdns_rec_powerdns_repo_45:
   yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-45/debug"
   name: "powerdns-rec-45"
 
+pdns_rec_powerdns_repo_46:
+  apt_repo_origin: "repo.powerdns.com"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-46 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
+  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
+  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-46"
+  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-46/debug"
+  name: "powerdns-rec-46"
+
+pdns_rec_powerdns_repo_47:
+  apt_repo_origin: "repo.powerdns.com"
+  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-47 main"
+  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
+  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
+  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-47"
+  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-47/debug"
+  name: "powerdns-rec-47"
+
+
 default_pdns_rec_service_overrides: >-
   {{  { 'User'  : pdns_rec_user
       , 'Group' : pdns_rec_group


### PR DESCRIPTION
just what is says on the subject
Successfully tested for pdns_rec_powerdns_repo_47 on Ubuntu 20.04.4 LTS.