### PR TITLE
Replace the deprecated include with include_task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,17 +8,17 @@
   tags:
     - always
 
-- include: "repo-{{ ansible_os_family }}.yml"
+- include_tasks: "repo-{{ ansible_os_family }}.yml"
   when: "pdns_rec_install_repo | length > 0"
   tags:
     - install
     - repository
 
-- include: "install-{{ansible_system}}.yml"
+- include_tasks: "install-{{ansible_system}}.yml"
   tags:
     - install
 
-- include: configure.yml
+- include_tasks: configure.yml
   tags:
     - config
 


### PR DESCRIPTION
This will fix the Deprecation warning: "ansible.builtin.include has been removed"

Currently Ansible runs are breaking with:

```ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.```