### PR TITLE
Add OL9, Rocky and AlmaLinux 8 and 9 as CI targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 4 * * 0'
 
 jobs:
   Tests:
@@ -18,6 +20,7 @@ jobs:
           - pdns-rec-49
           - pdns-rec-50
           - pdns-rec-master
+      fail-fast: false
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/molecule/pdns-rec-48/molecule.yml
+++ b/molecule/pdns-rec-48/molecule.yml
@@ -18,6 +18,10 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
+  - name: oraclelinux-9
+    image: oraclelinux:9
+    dockerfile_tpl: centos-systemd
+
   - name: ubuntu-2004
     image: ubuntu:20.04
     dockerfile_tpl: ubuntu-systemd
@@ -37,6 +41,22 @@ platforms:
   - name: debian-12
     image: debian:12
     dockerfile_tpl: debian-python3
+
+  - name: rockylinux-8
+    image: rockylinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-8
+    image: almalinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: rockylinux-9
+    image: rockylinux:9.0
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-9
+    image: almalinux:9
+    dockerfile_tpl: centos-systemd
 
 provisioner:
   name: ansible

--- a/molecule/pdns-rec-49/molecule.yml
+++ b/molecule/pdns-rec-49/molecule.yml
@@ -18,6 +18,10 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
+  - name: oraclelinux-9
+    image: oraclelinux:9
+    dockerfile_tpl: centos-systemd
+
   - name: ubuntu-2004
     image: ubuntu:20.04
     dockerfile_tpl: ubuntu-systemd
@@ -37,6 +41,22 @@ platforms:
   - name: debian-12
     image: debian:12
     dockerfile_tpl: debian-python3
+
+  - name: rockylinux-8
+    image: rockylinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-8
+    image: almalinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: rockylinux-9
+    image: rockylinux:9.0
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-9
+    image: almalinux:9
+    dockerfile_tpl: centos-systemd
 
 provisioner:
   name: ansible

--- a/molecule/pdns-rec-50/molecule.yml
+++ b/molecule/pdns-rec-50/molecule.yml
@@ -17,6 +17,10 @@ platforms:
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
+
+  - name: oraclelinux-9
+    image: oraclelinux:9
+    dockerfile_tpl: centos-systemd
   
   - name: ubuntu-2004
     image: ubuntu:20.04
@@ -37,6 +41,22 @@ platforms:
   - name: debian-12
     image: debian:12
     dockerfile_tpl: debian-python3
+
+  - name: rockylinux-8
+    image: rockylinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-8
+    image: almalinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: rockylinux-9
+    image: rockylinux:9.0
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-9
+    image: almalinux:9
+    dockerfile_tpl: centos-systemd
 
 provisioner:
   name: ansible

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -18,6 +18,10 @@ platforms:
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
 
+  - name: oraclelinux-9
+    image: oraclelinux:9
+    dockerfile_tpl: centos-systemd
+
   - name: ubuntu-2004
     image: ubuntu:20.04
     dockerfile_tpl: ubuntu-systemd
@@ -37,6 +41,22 @@ platforms:
   - name: debian-12
     image: debian:12
     dockerfile_tpl: debian-python3
+
+  - name: rockylinux-8
+    image: rockylinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-8
+    image: almalinux:8
+    dockerfile_tpl: centos-systemd
+
+  - name: rockylinux-9
+    image: rockylinux:9.0
+    dockerfile_tpl: centos-systemd
+
+  - name: almalinux-9
+    image: almalinux:9
+    dockerfile_tpl: centos-systemd
 
 provisioner:
   name: ansible

--- a/molecule/resources/Dockerfile.centos-systemd.j2
+++ b/molecule/resources/Dockerfile.centos-systemd.j2
@@ -5,7 +5,7 @@ FROM {{ item.image }}
 ENV container docker
 
 # Configure systemd to run into the container (see https://hub.docker.com/_/centos/)
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN (cd /lib/systemd/system/sysinit.target.wants/ && for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
@@ -22,6 +22,6 @@ VOLUME [ "/sys/fs/cgroup" ]
 
 CMD ["/usr/sbin/init"]
 
-RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python*-dnf bash iproute && dnf clean all; \
+RUN if [ $(command -v dnf) ] && [ $(rpm -E %{rhel}) -eq 8 ] || [ $(rpm -E %{rhel}) -eq 9 ]; then dnf makecache && dnf --assumeyes install python3 python3-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl net-tools bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; fi

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 debian_os = ['debian', 'ubuntu']
-rhel_os = ['redhat', 'centos', 'ol']
+rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 
 @pytest.fixture()

--- a/molecule/resources/tests/repo-48/test_repo_48.py
+++ b/molecule/resources/tests/repo-48/test_repo_48.py
@@ -1,6 +1,6 @@
 
 debian_os = ['debian', 'ubuntu']
-rhel_os = ['redhat', 'centos', 'ol']
+rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 
 def test_repo_file(host):

--- a/molecule/resources/tests/repo-49/test_repo_49.py
+++ b/molecule/resources/tests/repo-49/test_repo_49.py
@@ -1,6 +1,6 @@
 
 debian_os = ['debian', 'ubuntu']
-rhel_os = ['redhat', 'centos', 'ol']
+rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 
 def test_repo_file(host):

--- a/molecule/resources/tests/repo-50/test_repo_50.py
+++ b/molecule/resources/tests/repo-50/test_repo_50.py
@@ -1,6 +1,6 @@
 
 debian_os = ['debian', 'ubuntu']
-rhel_os = ['redhat', 'centos', 'ol']
+rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 
 def test_repo_file(host):

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -1,6 +1,6 @@
 
 debian_os = ['debian', 'ubuntu']
-rhel_os = ['redhat', 'centos', 'ol']
+rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 
 def test_repo_file(host):

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -6,7 +6,7 @@
       package:
         name: epel-release
         state: present
-      when: ansible_distribution in [ 'CentOS' ]
+      when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
 
     - name: Install epel-release on RHEL
       package:
@@ -14,10 +14,11 @@
         state: present
       when: ansible_distribution in [ 'RedHat' ]
 
-    # FIXME: this only works for 8
     - name: Install epel-release on OracleLinux
       package:
-        name: oracle-epel-release-el8
+        name:
+        - "oracle-epel-release-el{{ ansible_distribution_major_version }}"
+        - hostname
         state: present
       when: ansible_distribution in [ 'OracleLinux' ]
 
@@ -27,8 +28,9 @@
   package:
     name: yum-plugin-priorities
     state: present
-  when: ansible_distribution in [ 'CentOS' ]
-    and ansible_pkg_mgr in [ 'yum' ]
+  when:
+    - ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
+    - ansible_distribution_major_version | int < 8
 
 - name: Add the PowerDNS Recursor YUM Repository
   yum_repository:


### PR DESCRIPTION
Added OL9, Rocky, and AlmaLinux 8 and 9 as CI targets.

Test `main` workflow weekly and make it not stop on failure so the remaining distros are tested.