### PR TITLE
Fix all non line-length related ansible linting errors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ pdns_rec_install_repo: ""
 
 # Install the EPEL repository.
 # EPEL is needed to satisfy some PowerDNS Recursor dependencies like protobuf
-pdns_rec_install_epel: True
+pdns_rec_install_epel: true
 
 # You can install the PowerDNS Recursor package from the 'master' branch as
 # follows:
@@ -43,7 +43,7 @@ pdns_rec_package_name: "{{ default_pdns_rec_package_name }}"
 pdns_rec_package_version: ""
 
 # Install PowerDNS Recursor debug symbols package
-pdns_rec_install_debug_symbols_package: False
+pdns_rec_install_debug_symbols_package: false
 
 # The name of the PowerDNS Recursor debug symbols package
 pdns_rec_debug_symbols_package_name: "{{ default_pdns_rec_debug_symbols_package_name }}"
@@ -57,36 +57,35 @@ pdns_rec_user: "{{ default_pdns_rec_user }}"
 pdns_rec_group: "{{ default_pdns_rec_group }}"
 
 # The user and group that own the configuration files
-pdns_rec_file_owner: "root"
+pdns_rec_file_owner: root
 pdns_rec_file_group: "{{ default_pdns_rec_file_group }}"
 
 # Name of the PowerDNS Service
-pdns_rec_service_name: "pdns-recursor"
+pdns_rec_service_name: pdns-recursor
 # Name of the PowerDNS binary.
-pdns_rec_bin_name: "pdns_recursor"
+pdns_rec_bin_name: pdns_recursor
 
 # State of the PowerDNS Recursor service
-pdns_rec_service_state: "started"
+pdns_rec_service_state: started
 pdns_rec_service_enabled: "yes"
 
 # When True, disable the automated restart of the PowerDNS Recursor service
-pdns_rec_disable_handlers: False
+pdns_rec_disable_handlers: false
 
 # Configuration directory and files
 pdns_rec_config_dir: "{{ default_pdns_rec_config_dir }}"
-pdns_rec_config_file: "recursor.conf"
+pdns_rec_config_file: recursor.conf
 pdns_rec_config_lua: "{{ pdns_rec_config_dir }}/config.lua"
 pdns_rec_config_lua_file_content: ""
 pdns_rec_config_dns_script: "{{ pdns_rec_config_dir }}/dns-script.lua"
 pdns_rec_config_dns_script_file_content: ""
 
 # Mode for directories from include-dir
-pdns_rec_config_include_dir_mode: 0750
+pdns_rec_config_include_dir_mode: "0750"
 
 # Directories and files required by recursor configuration
-pdns_rec_config_from_files_dir_mode: 0750
+pdns_rec_config_from_files_dir_mode: "0750"
 pdns_rec_config_from_files: []
-
 # Dict containing all configuration options, except for the
 # "config-dir", "setuid" and "setgid" directives in YAML format.
 pdns_rec_config: {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,18 +1,18 @@
 ---
 
 galaxy_info:
-  role_name: "pdns_recursor"
-  namespace: "powerdns"
+  role_name: pdns_recursor
+  namespace: powerdns
   author: PowerDNS Engineering Team
   description: Install and configure the PowerDNS Recursor
   company: PowerDNS.COM BV
   license: MIT
-  min_ansible_version: 2.12
+  min_ansible_version: "2.12"
   platforms:
     - name: EL
       versions:
-        - 7
-        - 8
+        - "7"
+        - "8"
     - name: Debian
       versions:
         - bullseye
@@ -24,8 +24,8 @@ galaxy_info:
         - jammy
     - name: FreeBSD
       versions:
-        - 11
-        - 12
+        - "11.0"
+        - "12.0"
   galaxy_tags:
     - system
     - dns

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,59 +1,60 @@
 ---
-
-- block:
-
+- name: Configure systemd
+  when: ansible_service_mgr == "systemd"
+  block:
     - name: Ensure the PowerDNS Recursor drop-in unit overrides directory exists (systemd)
-      file:
-        name: "/etc/systemd/system/{{ pdns_rec_service_name }}.service.d"
+      ansible.builtin.file:
+        name: /etc/systemd/system/{{ pdns_rec_service_name }}.service.d
         state: directory
         owner: root
         group: root
+        mode: "0750"
 
     - name: Override the PowerDNS Recursor unit (systemd)
-      template:
-        src: "override-service.systemd.conf.j2"
-        dest: "/etc/systemd/system/{{ pdns_rec_service_name }}.service.d/override.conf"
+      ansible.builtin.template:
+        src: override-service.systemd.conf.j2
+        dest: /etc/systemd/system/{{ pdns_rec_service_name }}.service.d/override.conf
         owner: root
         group: root
+        mode: "0640"
       when: pdns_rec_service_overrides | length > 0
       register: _pdns_recursor_override_unit
 
     - name: Reload systemd
-      command: systemctl daemon-reload
-      when: not pdns_rec_disable_handlers
-        and _pdns_recursor_override_unit.changed
-
-  when: ansible_service_mgr == "systemd"
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+      when: not pdns_rec_disable_handlers and _pdns_recursor_override_unit.changed
 
 - name: Ensure that the PowerDNS Recursor configuration directory exists
-  file:
+  ansible.builtin.file:
     name: "{{ pdns_rec_config_dir }}"
     state: directory
     owner: "{{ pdns_rec_file_owner }}"
     group: "{{ pdns_rec_file_group }}"
-    mode: 0750
+    mode: "0750"
 
 - name: Generate the PowerDNS Recursor configuration
-  template:
+  ansible.builtin.template:
     src: recursor.conf.j2
     dest: "{{ pdns_rec_config_dir }}/{{ pdns_rec_config_file }}"
     owner: "{{ pdns_rec_file_owner }}"
     group: "{{ pdns_rec_file_group }}"
-    mode: 0640
+    mode: "0640"
   register: _pdns_recursor_configuration
 
 - name: Ensure that the PowerDNS Recursor 'include-dir' directory exists
-  file:
+  ansible.builtin.file:
     name: "{{ pdns_rec_config['include-dir'] }}"
     state: directory
     owner: "{{ pdns_rec_file_owner }}"
     group: "{{ pdns_rec_file_group }}"
     mode: "{{ pdns_rec_config_include_dir_mode }}"
-  when: "pdns_rec_config['include-dir'] is defined"
+  when: pdns_rec_config['include-dir'] is defined
   register: _pdns_recursor_configuration_include_dir
 
-- block:
-
+- name: Configure from-files
+  when: pdns_rec_config_from_files | length > 0
+  block:
     - name: Ensure that the PowerDNS Recursor configuration from-files directory exists
       ansible.builtin.file:
         name: "{{ item.dest | dirname }}"
@@ -74,38 +75,36 @@
       loop: "{{ pdns_rec_config_from_files }}"
       register: _pdns_recursor_configuration_from_files
 
-  when: "pdns_rec_config_from_files | length > 0"
-
 - name: Generate the PowerDNS Recursor Lua config-file
-  copy:
+  ansible.builtin.copy:
     dest: "{{ pdns_rec_config_lua }}"
     content: "{{ pdns_rec_config_lua_file_content }}"
     owner: "{{ pdns_rec_file_owner }}"
     group: "{{ pdns_rec_file_group }}"
-    mode: 0640
+    mode: "0640"
   register: _pdns_recursor_lua_file_configuraton
-  when: "pdns_rec_config_lua_file_content | length > 0"
+  when: pdns_rec_config_lua_file_content | length > 0
 
 - name: Generate PowerDNS Recursor Lua dns-script
-  copy:
+  ansible.builtin.copy:
     dest: "{{ pdns_rec_config_dns_script }}"
     content: "{{ pdns_rec_config_dns_script_file_content }}"
     owner: "{{ pdns_rec_file_owner }}"
     group: "{{ pdns_rec_file_group }}"
-    mode: 0640
+    mode: "0640"
   register: _pdns_recursor_dns_script_configuration
-  when: "pdns_rec_config_dns_script_file_content | length > 0"
+  when: pdns_rec_config_dns_script_file_content | length > 0
 
 - name: Restart PowerDNS Recursor
-  service:
+  ansible.builtin.service:
     name: "{{ pdns_rec_service_name }}"
     state: restarted
     sleep: 1
   when: not pdns_rec_disable_handlers
     and pdns_rec_service_state != 'stopped'
     and (_pdns_recursor_override_unit.changed
-      or _pdns_recursor_configuration_include_dir.changed
-      or _pdns_recursor_configuration.changed
-      or _pdns_recursor_configuration_from_files.changed
-      or _pdns_recursor_lua_file_configuraton.changed
-      or _pdns_recursor_dns_script_configuration.changed)
+    or _pdns_recursor_configuration_include_dir.changed
+    or _pdns_recursor_configuration.changed
+    or _pdns_recursor_configuration_from_files.changed
+    or _pdns_recursor_lua_file_configuraton.changed
+    or _pdns_recursor_dns_script_configuration.changed)

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install the PowerDNS Recursor
-  pkgng:
+  community.general.packaging.os.pkgng:
     name: "{{ pdns_rec_package_name }}"
     state: present

--- a/tasks/install-Linux.yml
+++ b/tasks/install-Linux.yml
@@ -1,38 +1,38 @@
 ---
-
-- block:
-
+- name: Set package version facts
+  when: pdns_rec_package_version | length > 0
+  block:
     - name: Prefix the version of the PowerDNS Recursor package with the correct separator on RedHat
-      set_fact:
-        _pdns_rec_package_version: "-{{ pdns_rec_package_version }}"
+      ansible.builtin.set_fact:
+        _pdns_rec_package_version: -{{ pdns_rec_package_version }}
       when: ansible_os_family == 'RedHat'
 
     - name: Prefix the version of the PowerDNS Recursor package with the correct separator on Debian
-      set_fact:
-        _pdns_rec_package_version: "={{ pdns_rec_package_version }}"
+      ansible.builtin.set_fact:
+        _pdns_rec_package_version: ={{ pdns_rec_package_version }}
       when: ansible_os_family == 'Debian'
 
-  when: "pdns_rec_package_version | length > 0"
-
 - name: Install the PowerDNS Recursor
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_rec_package_name }}{{ _pdns_rec_package_version | default('') }}"
     state: present
 
 - name: Install PowerDNS Recursor debug symbols
-  package:
+  ansible.builtin.package:
     name: "{{ pdns_rec_debug_symbols_package_name }}{{ _pdns_rec_package_version | default('') }}"
     state: present
   when: pdns_rec_install_debug_symbols_package
 
-- block:
+- name: Get version from binaries
+  block:
     - name: Obtain pdns version string
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         {{ pdns_rec_bin_name }} --version 2>&1 | awk '/PowerDNS Recursor / {print $6}'
       register: _pdns_rec_ver_output
       changed_when: false
 
     - name: Set pdns version
-      set_fact:
+      ansible.builtin.set_fact:
         _pdns_rec_version: "{{ _pdns_rec_ver_output['stdout'] | regex_replace('-[.\\d\\w]+$', '') }}"
       when: not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,29 +1,31 @@
 ---
-
 - name: Include OS-specific variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_os_family }}.yml"
     - Other.yml
   tags:
     - always
 
-- include_tasks: "repo-{{ ansible_os_family }}.yml"
-  when: "pdns_rec_install_repo | length > 0"
+- name: Include OS specific repo tasks
+  ansible.builtin.include_tasks: repo-{{ ansible_os_family }}.yml
+  when: pdns_rec_install_repo | length > 0
   tags:
     - install
     - repository
 
-- include_tasks: "install-{{ansible_system}}.yml"
+- name: Include OS specific installation tasks
+  ansible.builtin.include_tasks: install-{{ ansible_system }}.yml
   tags:
     - install
 
-- include_tasks: configure.yml
+- name: Include configuration tasks
+  ansible.builtin.include_tasks: configure.yml
   tags:
     - config
 
 - name: Set the status of the PowerDNS Recursor service
-  service:
+  ansible.builtin.service:
     name: "{{ pdns_rec_service_name }}"
     state: "{{ pdns_rec_service_state }}"
     enabled: "{{ pdns_rec_service_enabled }}"

--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -1,38 +1,37 @@
 ---
-
 - name: Install gnupg
-  package:
+  ansible.builtin.package:
     name: gnupg
     state: present
 
 - name: Install apt-transport-https
-  package:
+  ansible.builtin.package:
     name: apt-transport-https
     state: present
 
 - name: Import the PowerDNS Recursor APT Repository key
-  apt_key:
+  ansible.builtin.apt_key:
     url: "{{ pdns_rec_install_repo['gpg_key'] }}"
     id: "{{ pdns_rec_install_repo['gpg_key_id'] | default('') }}"
     state: present
   register: _pdns_rec_apt_key
 
 - name: Add the PowerDNS Recursor APT Repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     filename: "{{ pdns_rec_install_repo['name'] }}"
     repo: "{{ pdns_rec_install_repo['apt_repo'] }}"
     state: present
   register: _pdns_rec_apt_repo
 
 - name: Update the APT cache
-  apt:
-    update_cache: yes
-  when: "_pdns_rec_apt_key.changed or _pdns_rec_apt_repo.changed"
+  ansible.builtin.apt:
+    update_cache: true
+  when: _pdns_rec_apt_key.changed or _pdns_rec_apt_repo.changed
 
 - name: Pin the PowerDNS Recursor APT Repository
-  template:
+  ansible.builtin.template:
     src: pdns-recursor.pin.j2
     dest: /etc/apt/preferences.d/pdns-recursor
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"

--- a/tasks/repo-RedHat.yml
+++ b/tasks/repo-RedHat.yml
@@ -1,31 +1,29 @@
 ---
-
-- block:
-
+- name: Install epel-release package depending on OS
+  when: pdns_rec_install_epel
+  block:
     - name: Install epel-release on CentOS
-      package:
+      ansible.builtin.package:
         name: epel-release
         state: present
       when: ansible_distribution in [ 'CentOS', 'Rocky', 'AlmaLinux' ]
 
     - name: Install epel-release on RHEL
-      package:
-        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+      ansible.builtin.package:
+        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
         state: present
       when: ansible_distribution in [ 'RedHat' ]
 
     - name: Install epel-release on OracleLinux
-      package:
+      ansible.builtin.package:
         name:
-        - "oracle-epel-release-el{{ ansible_distribution_major_version }}"
-        - hostname
+          - oracle-epel-release-el{{ ansible_distribution_major_version }}
+          - hostname
         state: present
       when: ansible_distribution in [ 'OracleLinux' ]
 
-  when: pdns_rec_install_epel
-
 - name: Install yum-plugin-priorities
-  package:
+  ansible.builtin.package:
     name: yum-plugin-priorities
     state: present
   when:
@@ -33,24 +31,24 @@
     - ansible_distribution_major_version | int < 8
 
 - name: Add the PowerDNS Recursor YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ pdns_rec_install_repo['name'] }}"
     file: "{{ pdns_rec_install_repo['name'] }}"
     description: PowerDNS Recursor
     baseurl: "{{ pdns_rec_install_repo['yum_repo_baseurl'] }}"
     gpgkey: "{{ pdns_rec_install_repo['gpg_key'] }}"
-    gpgcheck: yes
+    gpgcheck: true
     priority: "90"
     state: present
 
 - name: Add the PowerDNS Recursor debug symbols YUM Repository
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: "{{ pdns_rec_install_repo['name'] }}-debuginfo"
     file: "{{ pdns_rec_install_repo['name'] }}"
     description: PowerDNS Recursor - debug symbols
     baseurl: "{{ pdns_rec_install_repo['yum_debug_symbols_repo_baseurl'] }}"
     gpgkey: "{{ pdns_rec_install_repo['gpg_key'] }}"
-    gpgcheck: yes
+    gpgcheck: true
     priority: "90"
     state: present
   when: pdns_rec_install_debug_symbols_package

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 
-default_pdns_rec_user: "pdns"
-default_pdns_rec_group: "pdns"
+default_pdns_rec_user: pdns
+default_pdns_rec_group: pdns
 default_pdns_rec_file_group: "{{ default_pdns_rec_group }}"
-default_pdns_rec_config_dir: "/etc/powerdns"
-default_pdns_recorsor_debug_symbols_package_name: "pdns-recursor-dbg"
+default_pdns_rec_config_dir: /etc/powerdns
+default_pdns_recorsor_debug_symbols_package_name: pdns-recursor-dbg

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,7 +1,7 @@
 ---
 
-default_pdns_rec_user: "pdns_recursor"
-default_pdns_rec_group: "pdns"
-default_pdns_rec_file_group: "wheel"
-default_pdns_rec_config_dir: "/usr/local/etc/pdns-recursor"
-default_pdns_rec_package_name: "powerdns-recursor"
+default_pdns_rec_user: pdns_recursor
+default_pdns_rec_group: pdns
+default_pdns_rec_file_group: wheel
+default_pdns_rec_config_dir: /usr/local/etc/pdns-recursor
+default_pdns_rec_package_name: powerdns-recursor

--- a/vars/Other.yml
+++ b/vars/Other.yml
@@ -1,7 +1,7 @@
 ---
 
-default_pdns_rec_user: "pdns"
-default_pdns_rec_group: "pdns"
+default_pdns_rec_user: pdns
+default_pdns_rec_group: pdns
 default_pdns_rec_file_group: "{{ default_pdns_rec_group }}"
-default_pdns_rec_config_dir: "/etc/powerdns"
-default_pdns_recorsor_debug_symbols_package_name: "pdns-recursor-dbg"
+default_pdns_rec_config_dir: /etc/powerdns
+default_pdns_recorsor_debug_symbols_package_name: pdns-recursor-dbg

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 
-default_pdns_rec_user: "pdns-recursor"
-default_pdns_rec_group: "pdns-recursor"
+default_pdns_rec_user: pdns-recursor
+default_pdns_rec_group: pdns-recursor
 default_pdns_rec_file_group: "{{ default_pdns_rec_group }}"
-default_pdns_rec_config_dir: "/etc/pdns-recursor"
-default_pdns_rec_debug_symbols_package_name: "pdns-recursor-debuginfo"
+default_pdns_rec_config_dir: /etc/pdns-recursor
+default_pdns_rec_debug_symbols_package_name: pdns-recursor-debuginfo

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,43 +1,42 @@
 ---
 
-default_pdns_rec_package_name: "pdns-recursor"
+default_pdns_rec_package_name: pdns-recursor
 
 pdns_rec_powerdns_repo_master:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-master main"
-  gpg_key: "https://repo.powerdns.com/CBC8B383-pub.asc"
-  gpg_key_id: "D47975F8DAE32700A563E64FFF389421CBC8B383"
-  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-master"
-  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-master/debug"
-  name: "powerdns-rec-master"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-master main
+  gpg_key: https://repo.powerdns.com/CBC8B383-pub.asc
+  gpg_key_id: D47975F8DAE32700A563E64FFF389421CBC8B383
+  yum_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-master
+  yum_debug_symbols_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-master/debug
+  name: powerdns-rec-master
 
 pdns_rec_powerdns_repo_48:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-48 main"
-  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-48"
-  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-48/debug"
-  name: "powerdns-rec-48"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-48 main
+  gpg_key: https://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-48
+  yum_debug_symbols_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-48/debug
+  name: powerdns-rec-48
 
 pdns_rec_powerdns_repo_49:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-49 main"
-  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-49"
-  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-49/debug"
-  name: "powerdns-rec-49"
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-49 main
+  gpg_key: https://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-49
+  yum_debug_symbols_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-49/debug
+  name: powerdns-rec-49
 
 pdns_rec_powerdns_repo_50:
-  apt_repo_origin: "repo.powerdns.com"
-  apt_repo: "deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-50 main"
-  gpg_key: "https://repo.powerdns.com/FD380FBB-pub.asc"
-  gpg_key_id: "9FAAA5577E8FCF62093D036C1B0C6205FD380FBB"
-  yum_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-50"
-  yum_debug_symbols_repo_baseurl: "https://repo.powerdns.com/centos/$basearch/$releasever/rec-50/debug"
-  name: "powerdns-rec-50"
-
+  apt_repo_origin: repo.powerdns.com
+  apt_repo: deb [arch=amd64] https://repo.powerdns.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}-rec-50 main
+  gpg_key: https://repo.powerdns.com/FD380FBB-pub.asc
+  gpg_key_id: 9FAAA5577E8FCF62093D036C1B0C6205FD380FBB
+  yum_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-50
+  yum_debug_symbols_repo_baseurl: https://repo.powerdns.com/centos/$basearch/$releasever/rec-50/debug
+  name: powerdns-rec-50
 
 default_pdns_rec_service_overrides: >-
   {{  { 'User'  : pdns_rec_user


### PR DESCRIPTION
This commit fixes all ansible-lint errors except for disabled yaml[line-length]