### PR TITLE
Add Ubuntu 24.04 Noble

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
     - name: FreeBSD
       versions:
         - "11.0"

--- a/molecule/pdns-rec-50/molecule.yml
+++ b/molecule/pdns-rec-50/molecule.yml
@@ -30,6 +30,10 @@ platforms:
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
 
+  - name: ubuntu-2404
+    image: ubuntu:24.04
+    dockerfile_tpl: ubuntu-systemd
+
   - name: debian-10
     image: debian:10
     dockerfile_tpl: debian-systemd

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -30,6 +30,10 @@ platforms:
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
 
+  - name: ubuntu-2404
+    image: ubuntu:24.04
+    dockerfile_tpl: ubuntu-systemd
+
   - name: debian-10
     image: debian:10
     dockerfile_tpl: debian-systemd


### PR DESCRIPTION
Adds Ubuntu 24.04 Noble for versions listed on repo.powerdns.com (I.e 5.0 and master)