### PR TITLE
GH Actions: fix issues with CI

### DIFF
--- a/molecule/pdns-rec-48/molecule.yml
+++ b/molecule/pdns-rec-48/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/pdns-rec-49/molecule.yml
+++ b/molecule/pdns-rec-49/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/pdns-rec-50/molecule.yml
+++ b/molecule/pdns-rec-50/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -10,8 +10,8 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: centos-7
-    image: centos:7
+  - name: oraclelinux-7
+    image: oraclelinux:7
     dockerfile_tpl: centos-systemd
 
   - name: oraclelinux-8

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -60,5 +60,5 @@
         privileged: "yes"
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
-          - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+          - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/tests/repo-master/test_repo_master.py
+++ b/molecule/resources/tests/repo-master/test_repo_master.py
@@ -29,5 +29,5 @@ def test_pdns_repo(host):
 def test_pdns_version(host):
     cmd = host.run('/usr/sbin/pdns_recursor --version')
 
-    assert 'PowerDNS Recursor' in cmd.stderr
-    assert 'master' in cmd.stderr
+    assert 'PowerDNS Recursor' in cmd.stderr or 'PowerDNS Recursor' in cmd.stdout
+    assert 'master' in cmd.stderr or 'master' in cmd.stdout

--- a/molecule/resources/vars/pdns-rec-common.yml
+++ b/molecule/resources/vars/pdns-rec-common.yml
@@ -40,6 +40,3 @@ pdns_rec_config:
 pdns_rec_config_lua: "{{ pdns_rec_config_dir }}/rpz.lua"
 pdns_rec_config_lua_file_content: |
   rpzMaster("127.0.0.2", "rpz.test", {refresh=30})
-
-pdns_rec_service_overrides:
-  LimitCORE: infinity

--- a/molecule/resources/vars/pdns-rec-repo-47.yml
+++ b/molecule/resources/vars/pdns-rec-repo-47.yml
@@ -5,3 +5,6 @@
 ##
 
 pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_47 }}"
+
+pdns_rec_service_overrides:
+  LimitCORE: infinity

--- a/molecule/resources/vars/pdns-rec-repo-48.yml
+++ b/molecule/resources/vars/pdns-rec-repo-48.yml
@@ -5,3 +5,6 @@
 ##
 
 pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_48 }}"
+
+pdns_rec_service_overrides:
+  LimitCORE: infinity

--- a/molecule/resources/vars/pdns-rec-repo-49.yml
+++ b/molecule/resources/vars/pdns-rec-repo-49.yml
@@ -5,3 +5,6 @@
 ##
 
 pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_49 }}"
+
+pdns_rec_service_overrides:
+  LimitCORE: infinity

--- a/molecule/resources/vars/pdns-rec-repo-50.yml
+++ b/molecule/resources/vars/pdns-rec-repo-50.yml
@@ -5,3 +5,6 @@
 ##
 
 pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_50 }}"
+
+pdns_rec_service_overrides:
+  LimitCORE: infinity

--- a/molecule/resources/vars/pdns-rec-repo-master.yml
+++ b/molecule/resources/vars/pdns-rec-repo-master.yml
@@ -5,3 +5,7 @@
 ##
 
 pdns_rec_install_repo: "{{ pdns_rec_powerdns_repo_master }}"
+
+pdns_rec_service_overrides:
+  LimitCORE: infinity
+  ExecStart: /usr/sbin/pdns_recursor --daemon=no --write-pid=no --disable-syslog --log-timestamp=no --enable-old-settings

--- a/templates/override-service.systemd.conf.j2
+++ b/templates/override-service.systemd.conf.j2
@@ -1,4 +1,7 @@
 [Service]
 {% for k, v in pdns_rec_service_overrides.items() %}
+{% if k == 'ExecStart' %}ExecStart=
+{% elif k == 'ExecStartPre' %}ExecStartPre=
+{% endif %}
 {{ k }}={{ v }}
 {% endfor %}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ molecule-plugins[docker]==23.4.1
 molecule-plugins[lint]==23.4.1
 molecule==5.1.0
 pytest-testinfra==10.1.0
-docker==7.0.0
+docker==7.1.0


### PR DESCRIPTION
Included in this PR are fixes for:

- Version of `docker-py` set to 7.1.0. Older versions require a specific version of `requests` to work (see [here](https://github.com/docker/docker-py/issues/3256)
- Move from tests from`centos:7` to `oraclelinux:7`
- Adapt tests to comply with newer versions of rec that get the output of `/usr/sbin/pdns_recursor --version` through stdout instead of stderr.
- Mount `/sys/fs/cgroups` as `rw` to overcome the error that made containers fail after starting: `Failed to create /actions_job/b23bdd0759a907717ae61975e6bf5b5044ae8f9dee961e93a4c108e30868f395/init.scope control group: Read-only file system`