### PR TITLE
Removed EOL targets RHEL-7 and Debian-10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,12 +11,11 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - "7"
         - "8"
+        - "9"
     - name: Debian
       versions:
         - bullseye
-        - buster
         - bookworm
     - name: Ubuntu
       versions:

--- a/molecule/pdns-rec-48/molecule.yml
+++ b/molecule/pdns-rec-48/molecule.yml
@@ -10,10 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
@@ -29,10 +25,6 @@ platforms:
   - name: ubuntu-2204
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
-
-  - name: debian-10
-    image: debian:10
-    dockerfile_tpl: debian-systemd
 
   - name: debian-11
     image: debian:11

--- a/molecule/pdns-rec-49/molecule.yml
+++ b/molecule/pdns-rec-49/molecule.yml
@@ -10,10 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
@@ -29,10 +25,6 @@ platforms:
   - name: ubuntu-2204
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
-
-  - name: debian-10
-    image: debian:10
-    dockerfile_tpl: debian-systemd
 
   - name: debian-11
     image: debian:11

--- a/molecule/pdns-rec-50/molecule.yml
+++ b/molecule/pdns-rec-50/molecule.yml
@@ -10,10 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
@@ -29,10 +25,6 @@ platforms:
   - name: ubuntu-2204
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
-
-  - name: debian-10
-    image: debian:10
-    dockerfile_tpl: debian-systemd
 
   - name: debian-11
     image: debian:11

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -10,10 +10,6 @@ dependency:
   name: galaxy
 
 platforms:
-  - name: oraclelinux-7
-    image: oraclelinux:7
-    dockerfile_tpl: centos-systemd
-
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile_tpl: centos-systemd
@@ -29,10 +25,6 @@ platforms:
   - name: ubuntu-2204
     image: ubuntu:22.04
     dockerfile_tpl: ubuntu-systemd
-
-  - name: debian-10
-    image: debian:10
-    dockerfile_tpl: debian-systemd
 
   - name: debian-11
     image: debian:11


### PR DESCRIPTION
Fixes errors in CI.

Platforms removed:

- `oraclelinux-7`
- `debian-10`
