### PR TITLE
CI tests: upgraded version of molecule and ansible-core packages

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+skip_list:
+  - '306'  # [306] Shells that use pipes should set the pipefail option
+  - 'args' # [args] throws a warning on community.docker.docker_container for a correct attribute (cgroupns_mode)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,15 +6,21 @@ on:
     - cron: '0 4 * * 0'
 
 jobs:
+  Lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main
   Tests:
-    name: Test role
-    runs-on: ubuntu-20.04
+    name: Test role on different ansible versions
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ansible:
-          - "2.12"
-          - "2.13"
           - "2.14"
+          - "2.15"
+          - "2.16"
         scenario:
           - pdns-rec-48
           - pdns-rec-49
@@ -28,7 +34,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     name: Test role on different ansible versions
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         ansible:
           - "2.14"
@@ -27,7 +28,6 @@ jobs:
           - pdns-rec-50
           - pdns-rec-51
           - pdns-rec-master
-      fail-fast: false
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.yamllint
+++ b/.yamllint
@@ -1,16 +1,33 @@
+---
+# Based on ansible-lint config
 extends: default
 
 rules:
-
-  # Disable line-length and truthy values reporting
-  line-length: disable
-  truthy: disable
-
-  # Max 1 space to separate the elements in brakets
   braces:
     max-spaces-inside: 1
-
-  # Max 1 space in empty brackets
+    level: error
   brackets:
-    min-spaces-inside-empty: 0
-    max-spaces-inside-empty: 1
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/molecule/pdns-rec-48/converge.yml
+++ b/molecule/pdns-rec-48/converge.yml
@@ -1,8 +1,9 @@
 ---
 
-- hosts: all
+- name: PDNS Recursor 4.8
+  hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-48.yml
   roles:
-    - { role: pdns_recursor-ansible }
+    - { role: powerdns.pdns_recursor }

--- a/molecule/pdns-rec-49/converge.yml
+++ b/molecule/pdns-rec-49/converge.yml
@@ -1,8 +1,9 @@
 ---
 
-- hosts: all
+- name: PDNS Recursor 4.9
+  hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-49.yml
   roles:
-    - { role: pdns_recursor-ansible }
+    - { role: powerdns.pdns_recursor }

--- a/molecule/pdns-rec-50/converge.yml
+++ b/molecule/pdns-rec-50/converge.yml
@@ -1,8 +1,9 @@
 ---
 
-- hosts: all
+- name: PDNS Recursor 5.0
+  hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-50.yml
   roles:
-    - { role: pdns_recursor-ansible }
+    - { role: powerdns.pdns_recursor }

--- a/molecule/pdns-rec-51/converge.yml
+++ b/molecule/pdns-rec-51/converge.yml
@@ -1,8 +1,9 @@
 ---
 
-- hosts: all
+- name: PDNS Recursor 5.1
+  hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-51.yml
   roles:
-    - { role: pdns_recursor-ansible }
+    - { role: powerdns.pdns_recursor }

--- a/molecule/pdns-rec-master/converge.yml
+++ b/molecule/pdns-rec-master/converge.yml
@@ -1,8 +1,9 @@
 ---
 
-- hosts: all
+- name: PDNS Recursor Master
+  hosts: all
   vars_files:
     - ../resources/vars/pdns-rec-common.yml
     - ../resources/vars/pdns-rec-repo-master.yml
   roles:
-    - { role: pdns_recursor-ansible }
+    - { role: powerdns.pdns_recursor }

--- a/molecule/pdns-rec-master/molecule.yml
+++ b/molecule/pdns-rec-master/molecule.yml
@@ -82,4 +82,3 @@ verifier:
     # path relative to '../resources/tests/all'
     - ../repo-master/
     - ../systemd-overrides
-

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -61,4 +61,5 @@
         volumes:
           # Mount the cgroups fs to allow SystemD to run into the containers
           - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+        cgroupns_mode: host
       with_items: "{{ molecule_platform_instances }}"

--- a/molecule/resources/create.yml
+++ b/molecule/resources/create.yml
@@ -8,36 +8,42 @@
     - vars/molecule.yml
   tasks:
 
-    - set_fact:
+    - name: Get list of service instances
+      ansible.builtin.set_fact:
         molecule_service_instances: "{{ molecule_yml.platforms | selectattr('is_service', 'defined') | selectattr('is_service') | list }}"
-    - set_fact:
+
+    - name: Get list of platform instances
+      ansible.builtin.set_fact:
         molecule_platform_instances: "{{ molecule_yml.platforms | difference(molecule_service_instances) }}"
 
     - name: Create Dockerfiles from image names
-      template:
+      ansible.builtin.template:
         src: "Dockerfile.{{ item.dockerfile_tpl | default('default') }}.j2"
         dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+        mode: '0644'
       with_items: "{{ molecule_platform_instances }}"
       register: platforms
 
     - name: Discover local Docker images
-      docker_image_info:
+      community.docker.docker_image_info:
         name: "molecule_pdns_rec/{{ item.item.name }}"
       with_items: "{{ platforms.results }}"
       register: docker_images
 
     - name: Build an Ansible compatible image
-      docker_image:
+      community.docker.docker_image:
         source: build
         name: "molecule_pdns_rec/{{ item.item.image }}"
         build:
           path: "{{ molecule_ephemeral_directory }}"
           dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force_source: "{{ item.item.force | default(True) }}"
+        force_tag: "{{ item.item.force | default(True) }}"
       with_items: "{{ platforms.results }}"
       when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
 
     - name: Create molecule instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "{{ item.image }}"
@@ -49,7 +55,7 @@
       with_items: "{{ molecule_service_instances }}"
 
     - name: Create the required Services instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         hostname: "{{ item.name }}"
         image: "molecule_pdns_rec/{{ item.image }}"

--- a/molecule/resources/destroy.yml
+++ b/molecule/resources/destroy.yml
@@ -8,7 +8,7 @@
     - vars/molecule.yml
   tasks:
     - name: Destroy the target Platforms instance(s)
-      docker_container:
+      community.docker.docker_container:
         name: "{{ item.name }}"
         state: absent
         force_kill: "{{ item.force_kill | default(True) }}"

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -5,14 +5,15 @@
   tasks:
     # Install rsyslog to capture the PowerDNS Recursor log messages
     # when the service is not managed by systemd
-    - block:
+    - name: Install rsyslog
+      when: ansible_service_mgr != 'systemd'
+      block:
         - name: Install rsyslog
-          package:
+          ansible.builtin.package:
             name: rsyslog
             state: present
 
         - name: Start rsyslog
-          service:
+          ansible.builtin.service:
             name: rsyslog
             state: started
-      when: ansible_service_mgr != 'systemd'

--- a/molecule/resources/tests/all/test_common.py
+++ b/molecule/resources/tests/all/test_common.py
@@ -14,11 +14,11 @@ rhel_os = ['redhat', 'centos', 'ol', 'rocky', 'almalinux']
 
 @pytest.fixture()
 def AnsibleVars(host):
-    varsFiles = ["vars/main.yml"]
+    varsFiles = ["../../vars/main.yml"]
     if host.system_info.distribution.lower() in debian_os:
-        varsFiles.append("vars/Debian.yml")
+        varsFiles.append("../../vars/Debian.yml")
     if host.system_info.distribution.lower() in rhel_os:
-        varsFiles.append("vars/RedHat.yml")
+        varsFiles.append("../../vars/RedHat.yml")
 
     ansibleVars = {}
     for f in varsFiles:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 ansible-lint==24.12.2
+ansible-compat==24.10.0
 yamllint==1.35.1
 molecule-plugins[docker]==23.6.0
 molecule-plugins[lint]==23.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
-ansible-lint==24.2.1
+ansible-lint==24.12.2
 yamllint==1.35.1
-molecule-plugins[docker]==23.4.1
-molecule-plugins[lint]==23.4.1
-molecule==5.1.0
-pytest-testinfra==10.1.0
+molecule-plugins[docker]==23.6.0
+molecule-plugins[lint]==23.6.0
+molecule==24.9.0
+pytest-testinfra==10.1.1
 docker==7.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 1.8
-envlist = ansible{212,213,214}
+envlist = ansible{214,215,216}
 skipsdist = true
 
 [gh-actions:env]
 ANSIBLE=
-  2.12: ansible212
-  2.13: ansible213
   2.14: ansible214
+  2.15: ansible215
+  2.16: ansible216
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible212: ansible-core>2.12,<2.13
-    ansible213: ansible-core>2.13,<2.14
     ansible214: ansible-core>2.14,<2.15
+    ansible215: ansible-core>2.15,<2.16
+    ansible216: ansible-core>2.16,<2.17
 setenv =
   PY_COLORS = 1
 commands =


### PR DESCRIPTION
Tests now run against `ansible-core 2.14, 2.15 and 2.16`.

Added linter to CI workflow and fixed some lint issues