### PR TITLE
repo-Debian: remove installing apt-transport-https

### DIFF
--- a/tasks/repo-Debian.yml
+++ b/tasks/repo-Debian.yml
@@ -4,11 +4,6 @@
     name: gnupg
     state: present
 
-- name: Install apt-transport-https
-  ansible.builtin.package:
-    name: apt-transport-https
-    state: present
-
 - name: Import the PowerDNS Recursor APT Repository key
   ansible.builtin.apt_key:
     url: "{{ pdns_rec_install_repo['gpg_key'] }}"


### PR DESCRIPTION
HTTPS support has been integrated into apt in all supported versions of Debian and Ubuntu, and apt-transport-https is only a dummy package.

See: https://packages.debian.org/search?keywords=apt-transport-https