### PR TITLE
Ansible does not like comparing version to integer 0

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -47,7 +47,7 @@ default_pdns_rec_service_overrides: >-
 
 # Default value intended to be used during check mode, when proper version
 # detection does not run.
-_pdns_rec_version: "{{ pdns_rec_package_version if pdns_rec_package_version != '' else 0 }}"
+_pdns_rec_version: "{{ pdns_rec_package_version if pdns_rec_package_version != '' else '0' }}"
 
 pdns_rec_base_config:
   recursor:


### PR DESCRIPTION
Apprarently `version` test in Ansible does not work with `0` in `_pdns_rec_version` variable and reports it as zero. Using string with 0: `'0'` works fine