### PR TITLE
fix: using right regex to extract pdns_recursor version

### DIFF
--- a/tasks/install-Linux.yml
+++ b/tasks/install-Linux.yml
@@ -28,7 +28,7 @@
     - name: Obtain pdns version string
       ansible.builtin.shell: |
         set -o pipefail
-        {{ pdns_rec_bin_name }} --version 2>&1 | awk '/PowerDNS Recursor / {print $6}'
+        {{ pdns_rec_bin_name }} --version 2>&1 | grep 'PowerDNS Recursor ' | grep -oE '[0-9]+(\.[0-9]+)+'
       args:
         executable: /bin/bash
       register: _pdns_rec_ver_output


### PR DESCRIPTION
I deployed the role using this the 52 repo and got an issue about pdns version.

```
fatal: [REDACTED]: FAILED! => {"msg": "The conditional check 'pdns_rec_service_overrides | length > 0' failed. The error was: An unhandled exception occurred while templating '{{ default_pdns_rec_service_overrides }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{  { 'User'  : pdns_rec_user\n    , 'Group' : pdns_rec_group\n    } if _pdns_rec_version is version('4.3', operator='ge')\n      else {}\n}}'. Error was a <class 'ansible.errors.AnsibleFilterError'>, original message: Version comparison failed: '<' not supported between instances of 'str' and 'int'\n\nThe error appears to be in 'REDACTED/roles/PowerDNS.pdns_recursor/tasks/configure.yml': line 13, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Override the PowerDNS Recursor unit (systemd)\n      ^ here\n"}
```

At first, I thought like @Nokalov in #221 but I found that the version getter is initially not actually right. The original regex was extracting `BV`, because the line on my version is `PowerDNS Recursor 5.2.5 (C) PowerDNS.COM BV` and we ask awk to extract the 6th element.

Here is a small fix to it, we still match `PowerDNS Recursor ` line but we extract only the block matching MAJOR.MINOR (.PATCH accepted, and more subpatch if needed). 

You can test the regex `[0-9]+(\.[0-9]+)+` on https://regex101.com/ with the following values to check

```
5.2
5.2.3
5
5.2.34
5.12
5.12.31.0
12.0.2
```

I did not test it on 4.X versions.

I know #198 exists, but it looked to complex to me.